### PR TITLE
Differentiate Beginner and OSCP Learning Modes in Roadmaps

### DIFF
--- a/app.js
+++ b/app.js
@@ -1681,6 +1681,7 @@ async function generateRoadmapForCert(certId) {
             level: level,
             weaknesses: weaknesses,
             cert: certName,
+            mode: appState.learningMode,
             assessmentResult: appState.assessment
         });
         


### PR DESCRIPTION
This change addresses user feedback regarding the lack of foundational learning in "Beginner Mode". By passing the learning mode from the frontend to the backend AI prompts, we now ensure that beginners receive a roadmap starting from scratch (Networking, Linux, Windows, Scripting) using appropriate entry-level platforms like OverTheWire and TryHackMe, while keeping the OSCP Mode advanced and exam-focused.

---
*PR created automatically by Jules for task [10538376752496689448](https://jules.google.com/task/10538376752496689448) started by @hotaro6754*